### PR TITLE
Fix inlang.config.js

### DIFF
--- a/inlang.config.js
+++ b/inlang.config.js
@@ -12,7 +12,7 @@ export async function defineConfig(env) {
 
     plugins: [
       i18nextPlugin({
-        pathPattern: "./{language}/*.json",
+        pathPattern: "./{language}/all.json",
       }),
       standardLintRules(),
     ],


### PR DESCRIPTION
@dewil-official, I saw you were struggling with configuring the `inlang.config.js`.

### Why it's not working
With the update from major version 2 to 3 of `inlang/plugin-i18n`:
1. the wildcard `*` is not supported anymore
2. we introduced namespaces

### Supported Notation

#### Without namespaces

```typescript
pathPattern: "./resources/{language}.json"
```

#### With namespaces

> Does not get created by 'npx @inlang/cli config init'

```typescript
pathPattern: {
	common: "./resources/{language}/common.json"
	vital: "./resources/{language}/vital.json"
}
```

More about the recent changes in this readme:
https://github.com/inlang/inlang/tree/main/source-code/plugins/i18next

If you have any further questions, please feel free to contact me.