### PR TITLE
Japanese(Ja) Update translations

### DIFF
--- a/ja/all.json
+++ b/ja/all.json
@@ -1,0 +1,32 @@
+{
+  "LANGUAGE": {
+    "LANGUAGE_WORD": "言語"
+  },
+  "COMMON": {
+    "ACTIONS": {
+      "CREATE": "作成",
+      "REMOVE": "削除",
+      "DELETE": "削除",
+      "EDIT": "編集",
+      "DUPLICATE": "複製",
+      "APPLY": "適用",
+      "UPDATE": "更新",
+      "VIEW": "ビュー",
+      "HIDE": "非表示"
+    }
+  },
+  "SETTINGS": {
+    "ACCOUNT": {
+      "PROFILE_TITLE": "プロフィール",
+      "MY_PROFILE": "私のプロフィール",
+      "PROFILE": {
+        "KEYWORDS": "個人ユーザーのプロフィール"
+      },
+      "IMPORT_EXPORT_TITLE": "インポートとエクスポート",
+      "NAVIGATION_TITLE": "ナビゲーション",
+      "AUTHENTICATION_TITLE": "認証",
+      "ADVANCED_TITLE": "詳細設定",
+      "DANGER_ZONE_TITLE": "棄権ゾーン"
+    }
+  }
+}

--- a/project.inlang.json
+++ b/project.inlang.json
@@ -5,6 +5,7 @@
     "en",
     "cn",
     "de",
+    "ja",
     "ne",
     "pt-br",
     "tr",


### PR DESCRIPTION
Japanese has been newly added as a translation pack.
18 words have been translated into Japanese.
No translation has yet been added to keywords entry, due to the issues suggested below.
[ https://github.com/remnoteio/translation/issues/27 ](https://github.com/remnoteio/translation/issues/27)
I'll make a pull request for now, so as soon as it is approved, I'll make sure that the Japanese added by the app will be applied.